### PR TITLE
Allow description for email fields

### DIFF
--- a/src/main/scala/io/flow/lint/linters/CommonFieldsHaveNoDescriptions.scala
+++ b/src/main/scala/io/flow/lint/linters/CommonFieldsHaveNoDescriptions.scala
@@ -11,7 +11,7 @@ import com.bryzek.apidoc.spec.v0.models.{Field, Model, Service}
   */
 case object CommonFieldsHaveNoDescriptions extends Linter with Helpers {
 
-  val NamesWithNoDescriptions = Seq("id", "number", "guid", "email")
+  val NamesWithNoDescriptions = Seq("id", "number", "guid")
 
   override def validate(service: Service): Seq[String] = {
     service.models.filter(!_.name.endsWith("_form")).flatMap(validateModel(service, _))


### PR DESCRIPTION
  - we had a nice description of user.email in common API which
    makes me think we should allow this:

If known, the user's primary email address. While in most common cases, we expect users to have email addresses, there are edge cases where it is useful to allow a user to NOT have an email address. For example, users interacting solely from mobile devices, guest user accounts, initial onboarding where email is not known, etc. We think by starting off with an optional primary email address we can support these use cases with very little implementation cost.