### PR TITLE
Relax PUT response code validation

### DIFF
--- a/src/main/scala/io/flow/lint/linters/StandardResponse.scala
+++ b/src/main/scala/io/flow/lint/linters/StandardResponse.scala
@@ -10,7 +10,7 @@ import com.bryzek.apidoc.spec.v0.models.{ResponseCodeInt, ResponseCodeOption, Re
   * 
   *   GET: 200, 401
   *   POST: 200,401, 422
-  *   PUT: 200, 201, 401, 422
+  *   PUT: 401, 422
   *   DELETE: 204, 401, 404
   * 
   *   - 204 - verify type: unit
@@ -23,7 +23,7 @@ case object StandardResponse extends Linter with Helpers {
     Method.Get -> Seq(200, 401),
     Method.Patch -> Seq(200, 401, 404, 422),
     Method.Post -> Seq(201, 401, 422),
-    Method.Put -> Seq(200, 201, 401, 422),
+    Method.Put -> Seq(401, 422),
     Method.Delete -> Seq(204, 401, 404),
     Method.Head -> Nil,
     Method.Connect -> Nil,

--- a/src/test/scala/io/flow/lint/StandardResponseSpec.scala
+++ b/src/test/scala/io/flow/lint/StandardResponseSpec.scala
@@ -109,7 +109,7 @@ class StandardResponseSpec extends FunSpec with Matchers {
     )
   }
 
-  it("Put must have 200, 201, 401, 422") {
+  it("Put must have 401, 422") {
     linter.validate(
       buildService(
         Method.Put,
@@ -119,7 +119,7 @@ class StandardResponseSpec extends FunSpec with Matchers {
       )
     ) should be(
       Seq(
-        "Resource organizations PUT /organizations: Missing response codes: 200, 201, 401, 422"
+        "Resource organizations PUT /organizations: Missing response codes: 401, 422"
       )
     )
   }


### PR DESCRIPTION
 - Had an example of PUT /xxx where we only return a 200 (never a 201)
   as we are allowing update only for PUT