### PR TITLE
update validation

### DIFF
--- a/src/main/scala/io/flow/lint/linters/Get.scala
+++ b/src/main/scala/io/flow/lint/linters/Get.scala
@@ -52,22 +52,28 @@ case object Get extends Linter with Helpers {
     */
   private[this] case class Sublinter(leadingParam: String, trailingParams: Seq[String]) {
 
-    val RequiredParameters = Seq(leadingParam) ++ trailingParams
-
     def validateOperation(service: Service, resource: Resource, operation: Operation): Seq[String] = {
       val expansions = model(service, operation).map { m =>
         Expansions.fromFieldTypes(m.fields.map(_.`type`))
       }.getOrElse(Nil)
 
+      val requiredParams =
+        // if successful response type (2xx) references a model from another schema (i.e. [io.flow.example.v0.models.object]), no id parameter is required
+        // the resource is most likely manipulating/aggregating data rather than CRUD
+        if(responseType(operation).getOrElse("").contains("."))
+          trailingParams
+        else
+          Seq(leadingParam) ++ trailingParams
+
       val allRequiredParameters = expansions match {
-        case Nil => RequiredParameters
-        case _ => RequiredParameters ++ Seq(ExpandName)
+        case Nil => requiredParams
+        case _ => requiredParams ++ Seq(ExpandName)
       }
 
       val requiredErrors = queryParameters(operation).filter(p => p.required && p.default.isEmpty) match {
         case Nil => Nil
         case params => params.map { p =>
-          RequiredParameters.contains(p.name) match {
+          requiredParams.contains(p.name) match {
             case true => error(resource, operation, s"Parameter[${p.name}] must be optional")
             case false => error(resource, operation, s"Parameter[${p.name}] must be optional or must have a default")
           }
@@ -178,7 +184,11 @@ case object Get extends Linter with Helpers {
       Seq(
         names.head == leadingParam match {
           case true => Nil
-          case false => Seq(error(resource, operation, s"Parameter[$leadingParam] must be the first parameter"))
+          case false =>
+            if(!responseType(operation).getOrElse("").contains("."))
+              Seq(error(resource, operation, s"Parameter[$leadingParam] must be the first parameter"))
+            else
+              Nil
         },
         tail == expectedTail match {
           case true => {

--- a/src/main/scala/io/flow/lint/linters/Get.scala
+++ b/src/main/scala/io/flow/lint/linters/Get.scala
@@ -58,8 +58,9 @@ case object Get extends Linter with Helpers {
       }.getOrElse(Nil)
 
       val requiredParams =
-        // if successful response type (2xx) references a model from another schema (i.e. [io.flow.example.v0.models.object]), no id parameter is required
-        // the resource is most likely manipulating/aggregating data rather than CRUD
+        /** if successful response type (2xx) references a model from another schema (i.e. [io.flow.example.v0.models.object]), no id parameter is required
+          * the resource is most likely manipulating/aggregating data rather than CRUD
+          **/
         if(responseType(operation).getOrElse("").contains("."))
           trailingParams
         else

--- a/src/main/scala/io/flow/lint/linters/GetByIdIsExpandable.scala
+++ b/src/main/scala/io/flow/lint/linters/GetByIdIsExpandable.scala
@@ -33,7 +33,7 @@ case object GetByIdIsExpandable extends Linter with Helpers {
   }
 
   def returnsExpandableType(service: Service, op: Operation): Boolean = {
-    responseType(service, op) match {
+    responseType(op) match {
       case None => false
       case Some(t) => {
         Expansions.fromFieldTypes(Seq(t)) match {

--- a/src/main/scala/io/flow/lint/linters/Helpers.scala
+++ b/src/main/scala/io/flow/lint/linters/Helpers.scala
@@ -24,7 +24,7 @@ trait Helpers {
     * directly in the service (i.e. not imported)
     */
   def model(service: Service, operation: Operation): Option[Model] = {
-    responseType(service, operation).flatMap { t =>
+    responseType(operation).flatMap { t =>
       service.models.find(_.name == t)
     }
   }
@@ -33,7 +33,7 @@ trait Helpers {
     * Returns the name of the datatype for the successful response for this
     * operation.
     */
-  def responseType(service: Service, operation: Operation): Option[String] = {
+  def responseType(operation: Operation): Option[String] = {
     operation.responses.find(isSuccess(_)).map { response =>
       val i = response.`type`.lastIndexOf("[")
       if (i < 0) {

--- a/src/main/scala/io/flow/lint/linters/PrimaryResourcesHaveVersionsOperation.scala
+++ b/src/main/scala/io/flow/lint/linters/PrimaryResourcesHaveVersionsOperation.scala
@@ -53,8 +53,9 @@ case object PrimaryResourcesHaveVersionsOperation extends Linter with Helpers {
           }
         }
         case false => {
-          // if successful response type (2xx) references a model from another schema (i.e. [io.flow.example.v0.models.object]), no /versions endpoint is required
-          // the resource is most likely manipulating/aggregating data rather than CRUD
+          /** if successful response type (2xx) references a model from another schema (i.e. [io.flow.example.v0.models.object]), no id parameter is required
+            * the resource is most likely manipulating/aggregating data rather than CRUD
+            **/
           if (!responseType(item.operation).getOrElse("").contains("."))
             Some(error(item.resource, item.operation, s"Missing versions operation at path $versionPath"))
           else

--- a/src/test/scala/io/flow/lint/GetWithoutExpansionsSpec.scala
+++ b/src/test/scala/io/flow/lint/GetWithoutExpansionsSpec.scala
@@ -48,26 +48,49 @@ class GetWithoutExpansionsSpec extends FunSpec with Matchers {
   )
 
   def buildResourceWithSearch(params: Seq[Parameter]) = {
-      Services.withHealthcheck(
-        Services.Base.copy(
-          resources = Seq(
-            Resource(
-              `type` = "organization",
-              plural = "organizations",
-              operations = Seq(
-                Operation(
-                  method = Method.Get,
-                  path = "/organizations",
-                  parameters = params,
-                  responses = Seq(
-                    Services.buildResponse(`type` = "[organization]")
-                  )
+    Services.withHealthcheck(
+      Services.Base.copy(
+        resources = Seq(
+          Resource(
+            `type` = "organization",
+            plural = "organizations",
+            operations = Seq(
+              Operation(
+                method = Method.Get,
+                path = "/organizations",
+                parameters = params,
+                responses = Seq(
+                  Services.buildResponse(`type` = "[organization]")
                 )
               )
             )
           )
         )
       )
+    )
+  }
+
+  def buildResourceWithSearchAltSchemaResponse(params: Seq[Parameter]) = {
+    Services.withHealthcheck(
+      Services.Base.copy(
+        resources = Seq(
+          Resource(
+            `type` = "organization",
+            plural = "organizations",
+            operations = Seq(
+              Operation(
+                method = Method.Get,
+                path = "/organizations",
+                parameters = params,
+                responses = Seq(
+                  Services.buildResponse(`type` = "[io.flow.organization.v0.models.organization]")
+                )
+              )
+            )
+          )
+        )
+      )
+    )
   }
 
   it("GET / validation") {
@@ -130,6 +153,35 @@ class GetWithoutExpansionsSpec extends FunSpec with Matchers {
         "Resource organizations GET /organizations: Parameter[offset] must be optional"
       )
     )
+  }
+
+  it("GET / validates id not required") {
+    linter.validate(
+      buildResourceWithSearchAltSchemaResponse(
+        Seq(
+          Parameter(
+            name = "limit",
+            `type` = "string",
+            location = ParameterLocation.Query,
+            required = false
+          ),
+          Parameter(
+            name = "offset",
+            `type` = "int",
+            location = ParameterLocation.Query,
+            required = false,
+            minimum = Some(1),
+            maximum = Some(100)
+          ),
+          Parameter(
+            name = "sort",
+            `type` = "string",
+            location = ParameterLocation.Query,
+            required = false
+          )
+        )
+      )
+    ) should be(Nil)
   }
 
   it("GET / with required parameters in different order") {

--- a/src/test/scala/io/flow/lint/PrimaryResourcesHaveVersionsOperationSpec.scala
+++ b/src/test/scala/io/flow/lint/PrimaryResourcesHaveVersionsOperationSpec.scala
@@ -24,6 +24,11 @@ class PrimaryResourcesHaveVersionsOperationSpec extends FunSpec with Matchers {
     responseType = "[organization]"
   )
 
+  private[this] val getNoVersions = Services.buildSimpleOperation(
+    path = "/organizations",
+    responseType = "[io.flow.organization.v0.models.organization]"
+  )
+
   it("valid resource is left alone") {
     linter.validate(
       buildService(
@@ -44,6 +49,12 @@ class PrimaryResourcesHaveVersionsOperationSpec extends FunSpec with Matchers {
     ) should be(
       Seq("Resource organizations GET /organizations: Missing versions operation at path /organizations/versions")
     )
+  }
+
+  it("validates /versions resource is ok to be missing when 2xx response is a model from another schema") {
+    linter.validate(
+      buildService(Seq(getNoVersions))
+    ) should be(Nil)
   }
 
   it("validates version path at root") {


### PR DESCRIPTION
- if resource does not doing anything related to CRUD, no need for a /versions endpoint or 'id' parameter

- Check assumes if successful response contains alternate schema model, then it is most likely used for data manipulation/aggregating data.

Update:
We acknowledged this may be an issue, for example here, https://github.com/flowcommerce/api/blob/master/spec/organization.json#L144

Where /versions and 'id' would not be enforced, when it should be.

Continuing to think of a more robust solution..