### PR TITLE
Add 'proxy' command to generate config file for reverse proxy

### DIFF
--- a/src/main/scala/io/flow/build/Main.scala
+++ b/src/main/scala/io/flow/build/Main.scala
@@ -1,8 +1,7 @@
 package io.flow.build
 
 import com.bryzek.apidoc.spec.v0.models.Service
-import io.flow.lint
-import io.flow.oneapi
+import io.flow.{oneapi, lint, proxy}
 
 object Main extends App {
 
@@ -12,7 +11,8 @@ object Main extends App {
 
   private[this] val controllers = Seq(
     lint.Controller(),
-    oneapi.Controller()
+    oneapi.Controller(),
+    proxy.Controller()
   )
 
   ApidocConfig.load() match {

--- a/src/main/scala/io/flow/proxy/Controller.scala
+++ b/src/main/scala/io/flow/proxy/Controller.scala
@@ -1,0 +1,37 @@
+package io.flow.proxy
+
+import com.bryzek.apidoc.spec.v0.models.Service
+
+case class Controller() extends io.flow.build.Controller {
+
+  override val name = "Proxy"
+  override val command = "proxy"
+
+  def run(
+    services: Seq[Service]
+  ) (
+    implicit ec: scala.concurrent.ExecutionContext
+  ) {
+    println("Building proxy from: " + services.map(_.name).mkString(", "))
+
+    val all = services.map { service =>
+      ProxyBuilder(service).yaml()
+    }.mkString("\n")
+
+    val path = "/tmp/proxy.config"
+    writeToFile(path, all)
+    System.out.println(s"Proxy configuration written to ${path}")
+  }
+
+  private[this] def writeToFile(path: String, contents: String) {
+    import java.io.{BufferedWriter, File, FileWriter}
+
+    val bw = new BufferedWriter(new FileWriter(new File(path)))
+    try {
+      bw.write(contents)
+    } finally {
+      bw.close()
+    }
+  }
+  
+}

--- a/src/main/scala/io/flow/proxy/ProxyBuilder.scala
+++ b/src/main/scala/io/flow/proxy/ProxyBuilder.scala
@@ -20,8 +20,8 @@ case class ProxyBuilder(service: Service) {
 
     Seq(
       s"${service.name}:",
-      s"  - host: $host",
-      s"  - operations:",
+      s"  host: $host",
+      s"  operations:",
       routes.sorted.map { _.yaml }.mkString("    - ", "\n    - ", "")
     ).mkString("\n")
   }

--- a/src/main/scala/io/flow/proxy/ProxyBuilder.scala
+++ b/src/main/scala/io/flow/proxy/ProxyBuilder.scala
@@ -1,0 +1,29 @@
+package io.flow.proxy
+
+import com.bryzek.apidoc.spec.v0.models.Service
+
+case class ProxyBuilder(service: Service) {
+
+  private[this] val host = service.baseUrl.getOrElse {
+    s"https://${service.name.toLowerCase}.api.flow.io"
+  }
+
+  def yaml(): String = {
+    val routes = service.resources.map { resource =>
+      resource.operations.map { op =>
+        Route(
+          method = op.method.toString,
+          path = op.path
+        )
+      }
+    }.flatten
+
+    Seq(
+      s"${service.name}:",
+      s"  - host: $host",
+      s"  - operations:",
+      routes.sorted.map { _.yaml }.mkString("    - ", "\n    - ", "")
+    ).mkString("\n")
+  }
+
+}

--- a/src/main/scala/io/flow/proxy/Route.scala
+++ b/src/main/scala/io/flow/proxy/Route.scala
@@ -1,0 +1,14 @@
+package io.flow.proxy
+
+case class Route(method: String, path: String) extends Ordered[Route] {
+
+  private val sortKey = s"${path.toLowerCase}:${method.toLowerCase}"
+
+  def yaml = {
+    s"$method $path"
+  }
+
+  override def compare(that: Route) = {
+    sortKey.compare(that.sortKey)
+  }
+}

--- a/src/main/scala/io/flow/proxy/Text.scala
+++ b/src/main/scala/io/flow/proxy/Text.scala
@@ -1,0 +1,18 @@
+package io.flow.proxy
+
+object Text {
+
+  implicit class Indentable(s: String) {
+    def indent: String = indent(2)
+    def indent(width: Int): String = {
+      s.split("\n").map { value =>
+        if (value.trim == "") {
+          ""
+        } else {
+          (" " * width) + value
+        }
+      }.mkString("\n")
+    }
+  }
+
+}


### PR DESCRIPTION
- from sbt: run proxy flow/catalog flow/common flow/delivery_window flow/experience flow/fulfillment flow/harmonization flow/location flow/organization flow/payment flow/reference flow/search flow/tracking flow/user

 - output will be written to /tmp/proxy.config - sample:
```yaml
catalog:
  - host: https://catalog.api.flow.io
  - operations:
    - DELETE /:organization/attributes/:name
    - GET /:organization/attributes/:name
common:
  - host: https://api.flow.io
  - operations:
    - GET /_internal_/healthcheck
```